### PR TITLE
fix: Rustls initialization

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -44,6 +44,8 @@ pub async fn main(
     cli: &Cli,
     log_handle: Handle<LevelFilter, tracing_subscriber::Registry>,
 ) -> Result<(), Error> {
+    let _ = ic_bn_lib::rustls::crypto::ring::default_provider().install_default();
+
     ENV.set(cli.misc.env.clone()).unwrap();
     HOSTNAME.set(cli.misc.hostname.clone()).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,8 +68,6 @@ mod test {
 
     #[tokio::test]
     async fn test_load_balancer() {
-        let _ = ic_bn_lib::rustls::crypto::ring::default_provider().install_default();
-
         // Set up stub backend on a random port
         let opts = ServerOptions::default();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();


### PR DESCRIPTION
Move crypto provider init into `core::main`, otherwise the service can't initialize